### PR TITLE
README: update adafruit product URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Pre-requisites
 - Android Studio 2.2+
 - [Rainbow Hat for Android Things](https://shop.pimoroni.com/products/rainbow-hat-for-android-things) or the following individual components:
     - 1 [bmp280 temperature sensor](https://www.adafruit.com/product/2651)
-    - 1 [segment display with I2C backpack](https://www.adafruit.com/product/1270)
+    - 1 [segment display with I2C backpack](https://www.adafruit.com/product/879)
     - 1 push button
     - 1 resistor
     - jumper wires


### PR DESCRIPTION
Description should point to the `0.56"` alphanumerical version that's included in the [Adafruit kit](https://www.adafruit.com/product/3227).

Should we also update the schematics?